### PR TITLE
ci: update tagged release to softprops/action-gh-release

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Build
         run: go build -v .
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Release
+        uses: "softprops/action-gh-release@v2"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
           files: consul-wrapper


### PR DESCRIPTION
* Repository marvinpinto/action-automatic-releases has been archived last year.